### PR TITLE
fix(cleaning): support list byday in rrule

### DIFF
--- a/src/cleaning/config.py
+++ b/src/cleaning/config.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, model_validator
 class LinenChangeEntry(BaseModel):
     name: str = "Linen change"
     location: str
-    rrule: dict[str, str | int] | None = None
+    rrule: dict | None = None
     dates: list[datetime.date] | None = None
     description: str
 

--- a/src/cleaning/config.py
+++ b/src/cleaning/config.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, model_validator
 class LinenChangeEntry(BaseModel):
     name: str = "Linen change"
     location: str
-    rrule: dict | None = None
+    rrule: dict[str, str | int | list[str]] | None = None
     dates: list[datetime.date] | None = None
     description: str
 

--- a/src/cleaning/parser.py
+++ b/src/cleaning/parser.py
@@ -111,7 +111,7 @@ class LinenChangeEvent(BaseModel):
     date: datetime.date
     description: str
     location: str
-    rrule: dict[str, str | int] | None = None
+    rrule: dict | None = None
     rdate: list[datetime.date] | None = None
 
     @model_validator(mode="after")

--- a/src/cleaning/parser.py
+++ b/src/cleaning/parser.py
@@ -111,7 +111,7 @@ class LinenChangeEvent(BaseModel):
     date: datetime.date
     description: str
     location: str
-    rrule: dict | None = None
+    rrule: dict[str, str | int | list[str]] | None = None
     rdate: list[datetime.date] | None = None
 
     @model_validator(mode="after")

--- a/src/utils.py
+++ b/src/utils.py
@@ -87,6 +87,8 @@ def nearest_weekday(date: datetime.date, day: int | str | list[str]) -> datetime
     :rtype: datetime.date
     """
     if isinstance(day, list):
+        if not day:
+            raise ValueError("weekday list must not be empty")
         day = day[0]
 
     if isinstance(day, str):

--- a/src/utils.py
+++ b/src/utils.py
@@ -74,7 +74,7 @@ async def get_sheet_gids(spreadsheet_id: str) -> dict[str, str]:
         return sheet_mappings
 
 
-def nearest_weekday(date: datetime.date, day: int | str) -> datetime.date:
+def nearest_weekday(date: datetime.date, day: int | str | list[str]) -> datetime.date:
     """
     Returns the date of the next given weekday after
     the given date. For example, the date of next Monday.
@@ -82,10 +82,13 @@ def nearest_weekday(date: datetime.date, day: int | str) -> datetime.date:
     :param date: date to start from
     :type date: datetime.date
     :param day: weekday to find (0 is Monday, 6 is Sunday)
-    :type day: int
+    :type day: int | str | list[str]
     :return: date of the next given weekday
     :rtype: datetime.date
     """
+    if isinstance(day, list):
+        day = day[0]
+
     if isinstance(day, str):
         day = ["mo", "tu", "we", "th", "fr", "sa", "su"].index(day[:2].lower())
 


### PR DESCRIPTION
## Summary

- Accept `list[str]` for RRULE `byday` in `nearest_weekday` (e.g. `["th"]`).
- Widen linen-change `rrule` typing to `dict[str, str | int | list[str]]` so Pydantic accepts list `byday` values.

Closes #39

Note: all-day `validate_vevent` (#38) belongs in monorepo (`src/schedule/utils.py`), not this repo.

## Testing

- [ ] Unit tests pass
- [ ] CI green